### PR TITLE
Fix transaction total calculation

### DIFF
--- a/go/internal/market/entity/book.go
+++ b/go/internal/market/entity/book.go
@@ -98,7 +98,7 @@ func (b *Book) AddTransaction(transaction *Transaction, wg *sync.WaitGroup) {
 	transaction.BuyingOrder.Investor.UpdateAssetPosition(transaction.BuyingOrder.Asset.ID, minShares)
 	transaction.AddBuyOrderPendingShares(-minShares)
 
-	transaction.CalculateTotal(transaction.Shares, transaction.BuyingOrder.Price)
+	transaction.CalculateTotal(minShares)
 	transaction.CloseBuyOrder()
 	transaction.CloseSellOrder()
 	b.Transactions = append(b.Transactions, transaction)

--- a/go/internal/market/entity/transaction.go
+++ b/go/internal/market/entity/transaction.go
@@ -29,8 +29,8 @@ func NewTransaction(sellingOrder *Order, buyingOrder *Order, shares int, price f
 	}
 }
 
-func (t *Transaction) CalculateTotal(shares int, price float64) {
-	t.Total = float64(t.Shares) * t.Price
+func (t *Transaction) CalculateTotal(shares int) {
+	t.Total = float64(shares) * t.Price
 }
 
 func (t *Transaction) CloseBuyOrder() {


### PR DESCRIPTION
Eu não estava entendendo a lógica do microsserviço em Go do primeiro dia, principalmente porque sou dev Node, então eu tava revirando o código e adicionando testes pra conhecer mais os inputs e outputs do código.

O problema que eu encontrei é que o valor total da transaction estava pegando o valor total de shares em vez do valor de shares movimentado (`minShares`)

Se uma transaction era criada com 1.000.000 de shares, e `minShare` era 5, o valor transacionado deveria ser de 5 shares * price, mas o código estava somando todas as 1.000.000 de shares nessa transaction.

Eu achei que não fez sentido, por isso eu modifiquei o código, mas eu não entendo muito do domínio, nem de ações, nem de Go. Se esse for realmente o esperado, tudo certo. Apenas espero um feedback.

Valeu